### PR TITLE
Kwarg for the resource name length limit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ephemeral-pulumi-deploy"
-version = "0.0.1"
+version = "0.0.2"
 description = "Library for facilitating easy deployment of ephemeral pulumi stacks"
 authors = [
     {name = "Eli Fine"},

--- a/src/ephemeral_pulumi_deploy/__init__.py
+++ b/src/ephemeral_pulumi_deploy/__init__.py
@@ -2,8 +2,20 @@ from . import cli
 from . import utils
 from .cli import run_cli
 from .utils import append_resource_suffix
+from .utils import common_tags
+from .utils import common_tags_native
 from .utils import get_aws_account_id
 from .utils import get_config
 from .utils import get_config_str
 
-__all__ = ["append_resource_suffix", "cli", "get_aws_account_id", "get_config", "get_config_str", "run_cli", "utils"]
+__all__ = [
+    "append_resource_suffix",
+    "cli",
+    "common_tags",
+    "common_tags_native",
+    "get_aws_account_id",
+    "get_config",
+    "get_config_str",
+    "run_cli",
+    "utils",
+]

--- a/src/ephemeral_pulumi_deploy/cli.py
+++ b/src/ephemeral_pulumi_deploy/cli.py
@@ -52,7 +52,7 @@ def run_cli(*, stack_config: dict[str, Any], pulumi_program: PulumiFn) -> None:
         "on_output": print,
         # 'on_event': print   # TODO: figure out how to log these? Seems too verbose to print to stdout though
     }
-    if args.apply:
+    if args.up:
         up_response = stack.up(**up_and_preview_kwargs)
         up_response_str = result_to_str(up_response)
         logger.info(up_response_str)

--- a/src/ephemeral_pulumi_deploy/cli.py
+++ b/src/ephemeral_pulumi_deploy/cli.py
@@ -41,7 +41,7 @@ def run_cli(*, stack_config: dict[str, Any], pulumi_program: PulumiFn) -> None:
 
     # if destroy then teardown and exit
     if args.destroy:
-        destroy_response = stack.destroy()
+        destroy_response = stack.destroy(on_output=print)
         destroy_response_str = result_to_str(destroy_response)
         logger.info(destroy_response_str)
         # I see no reason not to completely remove the stack and history after destroying it. There is no returned output from the command https://github.com/pulumi/pulumi/blob/06ba63bb57e90706c1550861b785075ae860144a/sdk/python/lib/pulumi/automation/_local_workspace.py#L277

--- a/src/ephemeral_pulumi_deploy/utils.py
+++ b/src/ephemeral_pulumi_deploy/utils.py
@@ -64,9 +64,7 @@ def get_aws_region() -> str:
 SAFE_MAX_AWS_NAME_LENGTH = 56
 
 
-def append_resource_suffix(
-    resource_name: str = "",
-) -> str:
+def append_resource_suffix(resource_name: str = "", max_length: int = SAFE_MAX_AWS_NAME_LENGTH) -> str:
     """Append the suffix to the resource name.
 
     {resource_name}--{project_name}--{stack_name}
@@ -86,9 +84,9 @@ def append_resource_suffix(
     else:
         resource_name = RESOURCE_SUFFIX_DELIMITER.join((project_name, stack_name.lower()))
 
-    if len(resource_name) > SAFE_MAX_AWS_NAME_LENGTH:
+    if len(resource_name) > max_length:
         raise ValueError(  # noqa: TRY003 # this doesn't warrant a custom exception
-            f"Error creating aws resource name from template.\n{resource_name} is too long: {len(resource_name)} characters."
+            f"Error creating aws resource name from template.\n{resource_name} is too long (limit is {max_length}): {len(resource_name)} characters."
         )
     return resource_name
 
@@ -246,9 +244,9 @@ def get_stack(
 def common_tags() -> dict[str, str]:
     """Create common tags that all resources should have."""
     return {
-        "git-repository-url": get_config_str("proj:git_repository_url"),
-        "managed-by": "pulumi",
-        "stack-name": pulumi.get_stack(),
+        "iac-git-repository-url": get_config_str("proj:git_repository_url"),
+        "managed-via-iac-by": "pulumi",
+        "iac-stack-name": pulumi.get_stack(),
         "pulumi-project-name": pulumi.get_project(),
     }
 
@@ -270,5 +268,5 @@ _ = parser.add_argument(
     help="Pulumi stack name.",
 )
 
-_ = parser.add_argument("--apply", action="store_true")
+_ = parser.add_argument("--up", action="store_true")
 _ = parser.add_argument("--destroy", action="store_true")

--- a/tests/unit/test_resource_naming.py
+++ b/tests/unit/test_resource_naming.py
@@ -1,4 +1,8 @@
+import random
+import string
+
 import pulumi
+import pytest
 from pytest_mock import MockerFixture
 
 from ephemeral_pulumi_deploy import append_resource_suffix
@@ -13,3 +17,20 @@ def test_Given_long_stack_name__Then_truncated(mocker: MockerFixture):
     actual_full_name = append_resource_suffix(resource_name)
 
     assert actual_full_name.endswith(long_stack_name[:7])
+
+
+class TestGivenMockedStackAndProject:
+    @pytest.fixture(autouse=True)
+    def _setup(self, mocker: MockerFixture):
+        self.stack_value = "".join(random.choices(string.ascii_lowercase, k=10))
+        _ = mocker.patch.object(pulumi, "get_stack", autospec=True, return_value=self.stack_value)
+
+        _ = mocker.patch.object(
+            pulumi, "get_project", autospec=True, return_value="".join(random.choices(string.ascii_lowercase, k=10))
+        )
+
+    def test_Given_longer_limit_allowed__When_long_name__Then_no_error(self):
+        resource_name = "".join(random.choices(string.ascii_lowercase, k=70))
+        actual_full_name = append_resource_suffix(resource_name, max_length=100)
+
+        assert len(actual_full_name) > len(resource_name)

--- a/uv.lock
+++ b/uv.lock
@@ -625,7 +625,7 @@ wheels = [
 
 [[package]]
 name = "ephemeral-pulumi-deploy"
-version = "0.0.1"
+version = "0.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
 ## Why is this change necessary?
Many AWS resources allow longer names. Needed to be able to allow this to be longer when warranted.


 ## How does this change address the issue?
Adds a kwarg


 ## What side effects does this change have?
None


 ## How is this change tested?
Unit tests


 ## Other
Also altered the CLI to use the pulumi `up` term instead of terraform `apply`

Added some more common functions as directly importable from top-level namespace.
Clarified some tag keys
Made destroy logging more visible